### PR TITLE
[QCAWIFI-HOST-CMN] [8.1.r1] qdf: Fix build without WLAN_DEBUG

### DIFF
--- a/qdf/linux/src/qdf_trace.c
+++ b/qdf/linux/src/qdf_trace.c
@@ -1487,6 +1487,7 @@ uint8_t qdf_get_rate_limit_by_type(uint8_t type)
 	}
 }
 
+#ifdef WLAN_DEBUG
 /**
  * qdf_get_pkt_type_string() - Get the string based on pkt type
  * @type: packet type
@@ -1570,6 +1571,7 @@ uint8_t *qdf_get_pkt_status_string(uint8_t status)
 		return "unknown";
 	}
 }
+#endif
 
 /**
  * qdf_dp_log_proto_pkt_info() - Send diag log with pkt info
@@ -2077,6 +2079,7 @@ qdf_export_symbol(qdf_dp_display_proto_pkt_debug);
 void qdf_dp_display_proto_pkt_always(struct qdf_dp_trace_record_s *record,
 			      uint16_t index, uint8_t pdev_id, uint8_t info)
 {
+#ifdef WLAN_DEBUG
 	int loc;
 	char prepend_str[QDF_DP_TRACE_PREPEND_STR_SIZE];
 	struct qdf_dp_trace_proto_buf *buf =
@@ -2091,6 +2094,7 @@ void qdf_dp_display_proto_pkt_always(struct qdf_dp_trace_record_s *record,
 		 QDF_MAC_ADDR_ARRAY(buf->sa.bytes),
 		 qdf_dp_dir_to_str(buf->dir),
 		 QDF_MAC_ADDR_ARRAY(buf->da.bytes));
+#endif
 }
 qdf_export_symbol(qdf_dp_display_proto_pkt_always);
 

--- a/utils/logging/src/wlan_roam_debug.c
+++ b/utils/logging/src/wlan_roam_debug.c
@@ -153,6 +153,7 @@ static char *wlan_roam_debug_string(uint32_t op)
  */
 void wlan_roam_debug_dump_table(void)
 {
+#ifdef WLAN_DEBUG
 	uint32_t i;
 	int32_t current_index;
 	struct wlan_roam_debug_rec *dbg_rec;
@@ -198,6 +199,7 @@ void wlan_roam_debug_dump_table(void)
 		roam_debug("arg1 = 0x%-8x arg2 = 0x%-8x", dbg_rec->arg1,
 			   dbg_rec->arg2);
 	} while (i != current_index);
+#endif
 }
 qdf_export_symbol(global_wlan_roam_debug_table);
 


### PR DESCRIPTION
WLAN_DEBUG was disabled in qcacld-3.0: fix the build here...