### PR TITLE
[LA.UM.8.1.r1] qca-wifi-host-cmn: Initialize dl_pipe in hif_get_wake_ce_id

### DIFF
--- a/hif/src/ce/ce_main.c
+++ b/hif/src/ce/ce_main.c
@@ -3596,7 +3596,7 @@ void hif_wlan_disable(struct hif_softc *scn)
 int hif_get_wake_ce_id(struct hif_softc *scn, uint8_t *ce_id)
 {
 	QDF_STATUS status;
-	uint8_t ul_pipe, dl_pipe;
+	uint8_t ul_pipe, dl_pipe = 0;
 	int ul_is_polled, dl_is_polled;
 
 	/* DL pipe for HTC_CTRL_RSVD_SVC should map to the wake CE */


### PR DESCRIPTION
Initialize to 0 or some compilers (GCC but not clang) will complain:

```
qca-wifi-host-cmn/hif/src/ce/ce_main.c:3613:9: error: 'dl_pipe' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  *ce_id = dl_pipe;
         ^
cc1: all warnings being treated as errors
```

Signed-off-by: Pablo Mendez Hernandez <pablomh@gmail.com>