### PR TITLE
[WIFI-HOST-CMN] [9.12.r1] wifi3.0: Fix PROD build

### DIFF
--- a/dp/wifi3.0/dp_rx_err.c
+++ b/dp/wifi3.0/dp_rx_err.c
@@ -227,19 +227,23 @@ dp_rx_link_desc_return_by_addr(struct dp_soc *soc,
 		hal_rx_msdu_link_desc_set(hal_soc,
 				src_srng_desc, link_desc_addr, bm_action);
 		status = QDF_STATUS_SUCCESS;
-	} else {
+	} else if (IS_ENABLED(CONFIG_DP_TRACE)) {
 		struct hal_srng *srng = (struct hal_srng *)wbm_rel_srng;
-
-		DP_STATS_INC(soc, rx.err.hal_ring_access_full_fail, 1);
+		if (!srng)
+			goto end;
 
 		dp_info_rl("WBM Release Ring (Id %d) Full(Fail CNT %u)",
 			   srng->ring_id,
-			   soc->stats.rx.err.hal_ring_access_full_fail);
+			   soc->stats.rx.err.hal_ring_access_full_fail + 1);
 		dp_info_rl("HP 0x%x Reap HP 0x%x TP 0x%x Cached TP 0x%x",
 			   *srng->u.src_ring.hp_addr,
 			   srng->u.src_ring.reap_hp,
 			   *srng->u.src_ring.tp_addr,
 			   srng->u.src_ring.cached_tp);
+	}
+end:
+	if (status != QDF_STATUS_SUCCESS) {
+		DP_STATS_INC(soc, rx.err.hal_ring_access_full_fail, 1);
 		QDF_BUG(0);
 	}
 done:

--- a/hal/wifi3.0/qca6390/hal_6390_rx.h
+++ b/hal/wifi3.0/qca6390/hal_6390_rx.h
@@ -556,8 +556,9 @@ static void hal_rx_dump_msdu_start_tlv_6390(void *msdustart, uint8_t dbg_level)
 static void hal_rx_dump_msdu_end_tlv_6390(void *msduend,
 					  uint8_t dbg_level)
 {
+#ifdef QDF_TRACE_PRINT_ENABLE
 	struct rx_msdu_end *msdu_end = (struct rx_msdu_end *)msduend;
-
+#endif
 	__QDF_TRACE_RL(dbg_level, QDF_MODULE_ID_DP,
 		       "rx_msdu_end tlv (1/2) - "
 		       "rxpcu_mpdu_filter_in_category: %x "

--- a/hif/src/ath_procfs.c
+++ b/hif/src/ath_procfs.c
@@ -245,6 +245,9 @@ void athdiag_procfs_remove(void)
 	}
 }
 #else
+int athdiag_procfs_init(void *scn);
+void athdiag_procfs_remove(void);
+
 int athdiag_procfs_init(void *scn)
 {
 	return 0;


### PR DESCRIPTION
When a build with no trace and no debug is performed, errors and
warnings (we have Werror here) are guaranteed.

Solve all of them to be able to perform a production build.