### PR TITLE
[9.16.r1] qcacmn: Fix -Wstrict-prototypes

### DIFF
--- a/hif/src/ce/ce_service_legacy.c
+++ b/hif/src/ce/ce_service_legacy.c
@@ -1317,7 +1317,7 @@ struct ce_ops ce_service_legacy = {
 #endif
 };
 
-struct ce_ops *ce_services_legacy()
+struct ce_ops *ce_services_legacy(void)
 {
 	return &ce_service_legacy;
 }


### PR DESCRIPTION
```
drivers/staging/wlan-qc/qcacld-3.0/../qca-wifi-host-cmn/
hif/src/ce/ce_service_legacy.c:1320:34: error: a function
declaration without a prototype is deprecated in all versions
of C [-Werror,-Wstrict-prototypes]
struct ce_ops *ce_services_legacy()
                                 ^
                                  void
1 error generated.
```